### PR TITLE
Scream emote play sound.

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -50,11 +50,10 @@
 	message = "screams!"
 	message_mime = "acts out a scream!"
 	emote_type = EMOTE_AUDIBLE | EMOTE_VISIBLE
-	only_forced_audio = TRUE
 	vary = TRUE
 
 /datum/emote/living/carbon/human/scream/get_sound(mob/living/carbon/human/user)
-	if(!istype(user))
+	if(!istype(user) || user.silent)
 		return
 
 	return user.dna.species.get_scream_sound(user)


### PR DESCRIPTION
## About The Pull Request

Эмоция «Крик» может воспроизводить звук, если ее вызывает игрок. Звук не воспроизводится, если кукла немая.

## Why It's Good For The Game

Этот ПР прошел предложку.
Исправляет несправедливость что при смехе есть звук, а при крике нет.

## Changelog

:cl:
soundadd: Scream emote can play sound if forced by player
/:cl:
